### PR TITLE
fix(security): 18 -> 4 audit findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,16 @@
     "eslint-config-next": "14.1.0",
     "prettier": "^3.2.4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "js-yaml": ">=4.2.0 <5",
+    "postcss": ">=8.5.10 <9",
+    "picomatch": ">=2.3.2 <3",
+    "flatted": ">=3.4.2 <4",
+    "minimatch": ">=9.0.7 <10",
+    "glob": ">=10.5.0 <11",
+    "@babel/runtime": ">=7.26.10 <8",
+    "nanoid": ">=3.3.8 <4",
+    "braces": ">=3.0.3 <4"
   }
 }


### PR DESCRIPTION
Security pins for transitive dependencies. **No application source changed.**

| Package set | Before | After | Critical |
| --- | --- | --- | --- |
| root | 18 | **4** | 1 → 1 |

## Approach

Each pin comes from this repo's own Dependabot advisories, set to that
advisory's `first_patched_version` and capped below the next major
(`>=x.y.z <x+1`).

Two failure modes this avoids:

- **A shared pin table across repos.** The version that patches a package for a
  2021 CRA app is often a *downgrade* for a 2026 Next app, silently
  reintroducing vulnerabilities.
- **An uncapped `>=`.** That lets the resolver jump a major and break APIs;
  `@babel/runtime@8.0.0` drops `helpers/esm/*` and breaks Next builds this way.

## Verification

Dependency resolution succeeds and the audit deltas above are measured, not
estimated. Builds were **not** run for these repos, so please run the app's own
build and tests before relying on this.

CI could not check it either: Actions fails at startup on private repos in this
account, which is a billing block rather than a workflow bug.

## Left alone deliberately

These are **direct** dependencies with outstanding advisories: `next`.
Bumping them changes app APIs and needs a test pass, so they are out of scope
for a dependency-pin PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
